### PR TITLE
Use osm-auth to make authenticated calls if possible

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,19 @@ DiffRowDirective = function() {
 };
 
 
+/**
+ * Directive for displaying the OSM login/logout links.
+ */
+LoginDirective = function() {
+  return {
+    templateUrl: 'osm-login.html',
+    controller: 'LoginCtrl',
+    controllerAs: 'ctrl',
+    replace: true,
+  };
+};
+
+
 // Configure routes.
 app.config(function($routeProvider) {
   $routeProvider
@@ -56,9 +69,11 @@ app.service('osmService', OsmService);
 // Controllers.
 app.controller('HomeCtrl', HomeCtrl);
 app.controller('HistoryCtrl', HistoryCtrl);
+app.controller('LoginCtrl', LoginCtrl);
 
 // Directives.
 app.directive('diffRow', DiffRowDirective);
+app.directive('osmLogin', LoginDirective);
 
 // Filters.
 app.filter('capitalize', () => s => s.charAt(0).toUpperCase() + s.slice(1));

--- a/index.html
+++ b/index.html
@@ -30,13 +30,16 @@
       <div class="footer">
         <div id="auth-pane" class="text-left col-md-6">
           <span id="user" class="hidden">
-            <span id="gravatar"></span>
-            <span id="uname"></span>
-            <span class="spacer">&middot;</span>
+            <a id="ulink" target="_blank">
+              <img id="uavatar" class="avatar auth-item"/>
+              <span id="uname" class="auth-item"></span>
+            </a>
+            <span class="auth-item spacer">&middot;</span>
           </span>
-          <a class="hidden" id="login">Login</a>
-          <a class="hidden" id="logout">Logout</a>
+          <a id="login" class="auth-item hidden">Login</a>
+          <a id="logout" class="auth-item hidden">Logout</a>
         </div>
+
         <div class="text-right col-md-6">
           <a href="https://github.com/PeWu/osm-history">Page source on GitHub</a>
         </div>
@@ -59,12 +62,24 @@
         var auth = osmService.auth;
 
         function done(err, xml) {
-          if (err) {
+          var user = xml && xml.getElementsByTagName('user')[0];
+          if (err || !user) {
             document.getElementById('user').innerHTML = 'Auth error! Try clearing your browser cache';
             return;
           }
-          var u = xml.getElementsByTagName('user')[0];
-          document.getElementById('uname').innerHTML = u.getAttribute('display_name');
+
+          var userName = user.getAttribute('display_name');
+          var userImage = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@master/svg/iD-sprite/icons/icon-avatar.svg';
+          var userURL = 'https://www.openstreetmap.org/user/' + encodeURIComponent(userName);
+          var img = user.getElementsByTagName('img');
+          if (img && img[0] && img[0].getAttribute('href')) {
+            userImage = img[0].getAttribute('href');
+          }
+
+          document.getElementById('uname').innerHTML = userName;
+          document.getElementById('uavatar').setAttribute('src', userImage);
+          document.getElementById('uavatar').setAttribute('alt', userName);
+          document.getElementById('ulink').setAttribute('href', userURL);
           document.getElementById('user').classList.remove('hidden');
         }
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <script src="https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/osm-auth@1/osmauth.min.js"></script>
     <script src="osm-service.js"></script>
+    <script src="login-ctrl.js"></script>
     <script src="home-ctrl.js"></script>
     <script src="history-ctrl.js"></script>
     <script src="app.js"></script>
@@ -26,92 +27,15 @@
       <h1><a ng-href="#/">OSM History Viewer</a></h1>
       <div ng-view></div>
       <div class="clearfix"></div>
-
       <div class="footer">
-        <div id="auth-pane" class="text-left col-md-6">
-          <span id="user" class="hidden">
-            <a id="ulink" target="_blank">
-              <img id="uavatar" class="avatar auth-item"/>
-              <span id="uname" class="auth-item"></span>
-            </a>
-            <span class="auth-item spacer">&middot;</span>
-          </span>
-          <a id="login" class="auth-item hidden">Login</a>
-          <a id="logout" class="auth-item hidden">Logout</a>
+        <div class="text-left col-md-6">
+          <osm-login></osm-login>
         </div>
-
         <div class="text-right col-md-6">
           <a href="https://github.com/PeWu/osm-history">Page source on GitHub</a>
         </div>
       </div>
     </div>
-
-    <script>
-      // wait for Angular to be ready..
-      var intervalID = window.setInterval(function () {
-        var elem = angular.element(document.querySelector('[ng-view]'));
-        var injector = elem.injector();
-        if (injector) {
-          window.clearInterval(intervalID);
-          onReady(injector);
-        }
-      }, 100);
-
-      function onReady(injector) {
-        var osmService = injector.get('osmService');
-        var auth = osmService.auth;
-
-        function done(err, xml) {
-          var user = xml && xml.getElementsByTagName('user')[0];
-          if (err || !user) {
-            document.getElementById('user').innerHTML = 'Auth error! Try clearing your browser cache';
-            return;
-          }
-
-          var userName = user.getAttribute('display_name');
-          var userImage = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@master/svg/iD-sprite/icons/icon-avatar.svg';
-          var userURL = 'https://www.openstreetmap.org/user/' + encodeURIComponent(userName);
-          var img = user.getElementsByTagName('img');
-          if (img && img[0] && img[0].getAttribute('href')) {
-            userImage = img[0].getAttribute('href');
-          }
-
-          document.getElementById('uname').innerHTML = userName;
-          document.getElementById('uavatar').setAttribute('src', userImage);
-          document.getElementById('uavatar').setAttribute('alt', userName);
-          document.getElementById('ulink').setAttribute('href', userURL);
-          document.getElementById('user').classList.remove('hidden');
-        }
-
-        function fetchDetails() {
-          auth.xhr({ method: 'GET', path: '/api/0.6/user/details' }, done);
-        }
-
-        document.getElementById('login').onclick = function() {
-          auth.authenticate(function() { update(); });
-        };
-
-        document.getElementById('logout').onclick = function() {
-          auth.logout();
-          update();
-        };
-
-        function update() {
-          if (auth.authenticated()) {
-            document.getElementById('login').classList.add('hidden');
-            document.getElementById('logout').classList.remove('hidden');
-            fetchDetails();
-          } else {
-            document.getElementById('login').classList.remove('hidden');
-            document.getElementById('logout').classList.add('hidden');
-            document.getElementById('user').classList.add('hidden');
-          }
-        }
-
-        update();
-      }
-    </script>
-
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.3/leaflet.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-leaflet-directive/0.10.0/angular-leaflet-directive.js"></script>
     <script src="https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/osm-auth@1/osmauth.min.js"></script>
     <script src="osm-service.js"></script>
     <script src="home-ctrl.js"></script>
     <script src="history-ctrl.js"></script>
@@ -25,10 +26,78 @@
       <h1><a ng-href="#/">OSM History Viewer</a></h1>
       <div ng-view></div>
       <div class="clearfix"></div>
-      <div class="text-right">
-        <a href="https://github.com/PeWu/osm-history">Page source on GitHub</a>
+
+      <div class="footer">
+        <div id="auth-pane" class="text-left col-md-6">
+          <span id="user" class="hidden">
+            <span id="gravatar"></span>
+            <span id="uname"></span>
+            <span class="spacer">&middot;</span>
+          </span>
+          <a class="hidden" id="login">Login</a>
+          <a class="hidden" id="logout">Logout</a>
+        </div>
+        <div class="text-right col-md-6">
+          <a href="https://github.com/PeWu/osm-history">Page source on GitHub</a>
+        </div>
       </div>
     </div>
+
+    <script>
+      // wait for Angular to be ready..
+      var intervalID = window.setInterval(function () {
+        var elem = angular.element(document.querySelector('[ng-view]'));
+        var injector = elem.injector();
+        if (injector) {
+          window.clearInterval(intervalID);
+          onReady(injector);
+        }
+      }, 100);
+
+      function onReady(injector) {
+        var osmService = injector.get('osmService');
+        var auth = osmService.auth;
+
+        function done(err, xml) {
+          if (err) {
+            document.getElementById('user').innerHTML = 'Auth error! Try clearing your browser cache';
+            return;
+          }
+          var u = xml.getElementsByTagName('user')[0];
+          document.getElementById('uname').innerHTML = u.getAttribute('display_name');
+          document.getElementById('user').classList.remove('hidden');
+        }
+
+        function fetchDetails() {
+          auth.xhr({ method: 'GET', path: '/api/0.6/user/details' }, done);
+        }
+
+        document.getElementById('login').onclick = function() {
+          auth.authenticate(function() { update(); });
+        };
+
+        document.getElementById('logout').onclick = function() {
+          auth.logout();
+          update();
+        };
+
+        function update() {
+          if (auth.authenticated()) {
+            document.getElementById('login').classList.add('hidden');
+            document.getElementById('logout').classList.remove('hidden');
+            fetchDetails();
+          } else {
+            document.getElementById('login').classList.remove('hidden');
+            document.getElementById('logout').classList.add('hidden');
+            document.getElementById('user').classList.add('hidden');
+          }
+        }
+
+        update();
+      }
+    </script>
+
+
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -37,5 +106,6 @@
 
       ga('create', 'UA-334534-13', 'auto');
     </script>
+
   </body>
 </html>

--- a/land.html
+++ b/land.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+<script>
+  opener.authComplete(window.location.href);
+  window.close();
+</script>
+</body>
+</html>

--- a/land.html
+++ b/land.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
-<head></head>
-<body>
-<script>
-  opener.authComplete(window.location.href);
-  window.close();
-</script>
-</body>
+  <head></head>
+  <body>
+    <script>
+      opener.authComplete(window.location.href);
+      window.close();
+    </script>
+  </body>
 </html>

--- a/login-ctrl.js
+++ b/login-ctrl.js
@@ -1,0 +1,6 @@
+/**
+ * Controller for the login component.
+ */
+LoginCtrl = function(osmService) {
+  this.osmService = osmService;
+}

--- a/osm-login.html
+++ b/osm-login.html
@@ -1,0 +1,11 @@
+<span>
+  <span ng-if="ctrl.osmService.authenticated()">
+    <a target="_blank" ng-href="{{ctrl.osmService.getUserDetails().url}}">
+      <img class="avatar auth-item" ng-src="{{ctrl.osmService.getUserDetails().img}}" alt="{{ctrl.osmService.getUserDetails().userName}}"/>
+      <span class="auth-item">{{ctrl.osmService.getUserDetails().userName}}</span>
+    </a>
+    <span class="auth-item spacer">&middot;</span>
+  </span>
+  <a class="auth-item" ng-click="ctrl.osmService.login()" ng-if="!ctrl.osmService.authenticated()">Login</a>
+  <a class="auth-item" ng-click="ctrl.osmService.logout()" ng-if="ctrl.osmService.authenticated()">Logout</a>
+</span>

--- a/osm-service.js
+++ b/osm-service.js
@@ -2,8 +2,15 @@
 API_URL_BASE = 'https://api.openstreetmap.org/api/0.6/';
 
 OsmService = function($http) {
+  this.auth = osmAuth({
+    oauth_consumer_key: 'XOoeKShN1NtkKvriuBMnNsPvmBGnWQOUnovgY9fM',
+    oauth_secret: '5648E77IcaiGbyVShU9g7tHfLfEllJcpsz0xvJm4',
+    land: 'land.html',
+    url: 'https://www.openstreetmap.org'
+  });
+
   this.ngHttp = $http;
-  
+
   /** Converter from XML to json. */
   this.x2js = new X2JS({
     // All XML nodes under <osm> can be repeated.

--- a/osm-service.js
+++ b/osm-service.js
@@ -1,7 +1,9 @@
 /** Base URL for accessing OSM API. */
 API_URL_BASE = 'https://api.openstreetmap.org/api/0.6/';
 
-OsmService = function($http, $q) {
+DEFAULT_USER_IMAGE = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@master/svg/iD-sprite/icons/icon-avatar.svg';
+
+OsmService = function($http, $q, $rootScope) {
   this.auth = osmAuth({
     oauth_consumer_key: 'XOoeKShN1NtkKvriuBMnNsPvmBGnWQOUnovgY9fM',
     oauth_secret: '5648E77IcaiGbyVShU9g7tHfLfEllJcpsz0xvJm4',
@@ -11,12 +13,17 @@ OsmService = function($http, $q) {
 
   this.ngHttp = $http;
   this.ngQ = $q;
+  this.ngRootScope = $rootScope;
 
   /** Converter from XML to json. */
   this.x2js = new X2JS({
     // All XML nodes under <osm> can be repeated.
     arrayAccessFormPaths: [/osm\..*/]
   });
+
+  if (this.auth.authenticated()) {
+    this.updateUserDetails();
+  }
 };
 
 
@@ -63,30 +70,35 @@ getSegments = function(nodes) {
 
 
 /**
+ * Fetches an OSM path as an authenticated request.
+ */
+OsmService.prototype.fetchAuthenticated = function(path) {
+  return this.ngQ((resolve, reject) =>
+    this.auth.xhr({ method: 'GET', path: '/api/0.6/' + path },
+      (err, xml) => {
+        if (err || !xml) {
+          reject(err || 'no xml');
+        } else {
+          var str = new XMLSerializer().serializeToString(xml);
+          resolve({ data: str });
+        }
+      }
+    ));
+};
+
+
+/**
  * Calls the given URL and returns OSM data as a list of json objects.
  * Adds a tagMap field to objects which stores a key-value map of the
  * object's tags.
  */
 OsmService.prototype.fetchOsm = function(path, objectType) {
-  var prom;
-  if (this.auth.authenticated()) {
-    prom = this.ngQ((resolve, reject) => {
-      this.auth.xhr({ method: 'GET', path: '/api/0.6/' + path },
-        (err, xml) => {
-          if (err || !xml) {
-            reject(err || 'no xml');
-          } else {
-            var str = new XMLSerializer().serializeToString(xml);
-            resolve({ data: str });
-          }
-        }
-      );
-    });
-  } else {
-    prom = this.ngHttp.get(API_URL_BASE + path);
-  }
+  var responsePromise =
+      this.auth.authenticated() ?
+      this.fetchAuthenticated(path) :
+      this.ngHttp.get(API_URL_BASE + path);
 
-  return prom.then(response => {
+  return responsePromise.then(response => {
     var data = this.x2js.xml_str2json(response.data).osm[objectType] || [];
     data.forEach(item => {
       if (item.tag) {
@@ -96,3 +108,38 @@ OsmService.prototype.fetchOsm = function(path, objectType) {
     return data;
   });
 };
+
+
+OsmService.prototype.updateUserDetails = function() {
+  this.fetchOsm('user/details', 'user').then(response => {
+    var img = response[0].img;
+    var userName = response[0]._display_name;
+    this.userDetails = {
+      userName,
+      img: (img && img[0] && img[0]._href) || DEFAULT_USER_IMAGE,
+      url: 'https://www.openstreetmap.org/user/' + encodeURIComponent(userName),
+    };
+  });
+};
+
+
+OsmService.prototype.authenticated = function() {
+  return this.auth.authenticated();
+};
+
+
+OsmService.prototype.login = function() {
+  this.auth.authenticate(
+      () => this.ngRootScope.$apply(
+          () => this.updateUserDetails()));
+};
+
+
+OsmService.prototype.logout = function() {
+  this.auth.logout();
+};
+
+
+OsmService.prototype.getUserDetails = function() {
+  return this.userDetails;
+}

--- a/style.css
+++ b/style.css
@@ -56,3 +56,7 @@ input[type=number]::-webkit-outer-spin-button {
 input[type=number] {
   -moz-appearance:textfield;
 }
+
+a {
+  cursor: pointer;
+}

--- a/style.css
+++ b/style.css
@@ -6,6 +6,11 @@
   margin-bottom: 10px;
 }
 
+span.spacer {
+  font-weight: bold;
+  margin: 0 5px;
+}
+
 label {
   margin-top: 6px;
 }
@@ -38,5 +43,5 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 input[type=number] {
-    -moz-appearance:textfield;
+  -moz-appearance:textfield;
 }

--- a/style.css
+++ b/style.css
@@ -6,9 +6,20 @@
   margin-bottom: 10px;
 }
 
-span.spacer {
+.avatar {
+  width: 30px;
+  height: 30px;
+  object-fit: cover;
+  border: 1px solid #ccc;
+  border-radius: 15px;
+}
+
+.auth-item {
+  margin: 0 2px;
+}
+
+.spacer {
   font-weight: bold;
-  margin: 0 5px;
 }
 
 label {


### PR DESCRIPTION
Hey @PeWu !  
The Mapbox team uses your osm-history tool a bunch and we are big fans! 👏 

It turns out that we are _such_ big fans, that when we use osm-history, we're starting to bump up against the OSM API's rate limit policy and get our IP address blacklisted.  😢 

Since https://github.com/openstreetmap/operations/issues/36 there is a straightforward fix for this:  make OSM API calls authenticated, and the rate limits will count per-user instead of per-IP.  

So, this PR:
- adds some simple controls to the footer to let a user login/logout and
- uses the [osm-auth](https://github.com/osmlab/osm-auth) library to make authenticated calls if the user is logged in.  (This is the same library that we use for other tools like iD and OSMCha).

Admittedly, I am not at all familiar with AngularJS, so some of the code that I've added is probably not the best way.  

For now, I've forked this project and have it saved to [osmlab/osm-history](https://github.com/osmlab/osm-history), so that our team can use it. 

Let me know what you think!


### example:

<img width="852" alt="Screenshot 2019-12-05 16 30 13" src="https://user-images.githubusercontent.com/38784/70275758-cd8a5500-177c-11ea-83f7-b2517ff11c18.png">
